### PR TITLE
feat(ui/theme): adopt full M3 theme with extended tokens

### DIFF
--- a/app/src/main/java/com/md/mypuzzleapp/presentation/common/PermissionHandler.kt
+++ b/app/src/main/java/com/md/mypuzzleapp/presentation/common/PermissionHandler.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 
@@ -75,8 +76,8 @@ fun PermissionHandler(
                 showRationale = false
                 onPermissionResult(false)
             },
-            title = { Text("Permission Required") },
-            text = { Text(rationale) },
+            title = { Text("Permission Required", maxLines = 1, overflow = TextOverflow.Ellipsis) },
+            text = { Text(rationale, maxLines = 1, overflow = TextOverflow.Ellipsis) },
             confirmButton = {
                 TextButton(
                     onClick = {
@@ -84,7 +85,7 @@ fun PermissionHandler(
                         requestPermissionLauncher.launch(permission)
                     }
                 ) {
-                    Text("Grant Permission")
+                    Text("Grant Permission", maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             },
             dismissButton = {
@@ -94,7 +95,7 @@ fun PermissionHandler(
                         onPermissionResult(false)
                     }
                 ) {
-                    Text("Cancel")
+                    Text("Cancel", maxLines = 1, overflow = TextOverflow.Ellipsis)
                 }
             }
         )

--- a/app/src/main/java/com/md/mypuzzleapp/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/md/mypuzzleapp/presentation/home/HomeScreen.kt
@@ -56,6 +56,7 @@ import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
 import com.md.mypuzzleapp.domain.model.Puzzle
 import com.md.mypuzzleapp.presentation.common.UiEvent
+import com.md.mypuzzleapp.ui.theme.LocalExtendedColors
 import kotlinx.coroutines.flow.collectLatest
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -66,6 +67,7 @@ fun HomeScreen(
 ) {
     val state = viewModel.state
     val snackbarHostState = remember { SnackbarHostState() }
+    val ext = LocalExtendedColors.current
     
     LaunchedEffect(key1 = true) {
         viewModel.uiEvent.collectLatest { event ->
@@ -84,10 +86,12 @@ fun HomeScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Puzzle Gallery") },
+                title = { Text("Puzzle Gallery", maxLines = 1, overflow = TextOverflow.Ellipsis) },
                 colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.primaryContainer,
-                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                    containerColor = ext.primaryBackground,
+                    titleContentColor = ext.onPrimaryBackground,
+                    navigationIconContentColor = ext.onPrimaryBackground,
+                    actionIconContentColor = ext.onPrimaryBackground
                 )
             )
         },
@@ -99,8 +103,8 @@ fun HomeScreen(
                 // Random Image FAB
                 FloatingActionButton(
                     onClick = { viewModel.onEvent(HomeEvent.FetchRandomImage) },
-                    containerColor = MaterialTheme.colorScheme.secondary,
-                    contentColor = MaterialTheme.colorScheme.onSecondary,
+                    containerColor = ext.secondaryBackground,
+                    contentColor = ext.onSecondaryBackground,
                     elevation = FloatingActionButtonDefaults.elevation()
                 ) {
                     Icon(
@@ -112,8 +116,8 @@ fun HomeScreen(
                 // Upload Image FAB
                 FloatingActionButton(
                     onClick = { viewModel.onEvent(HomeEvent.ShowUploadDialog) },
-                    containerColor = MaterialTheme.colorScheme.primary,
-                    contentColor = MaterialTheme.colorScheme.onPrimary,
+                    containerColor = ext.fabBackground,
+                    contentColor = ext.onFabBackground,
                     elevation = FloatingActionButtonDefaults.elevation()
                 ) {
                     Icon(
@@ -123,7 +127,8 @@ fun HomeScreen(
                 }
             }
         },
-        snackbarHost = { SnackbarHost(snackbarHostState) }
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        containerColor = MaterialTheme.colorScheme.background
     ) { paddingValues ->
         HomeContent(
             puzzles = state.puzzles,
@@ -186,13 +191,17 @@ fun HomeContent(
                 Text(
                     text = "No puzzles available",
                     style = MaterialTheme.typography.headlineSmall,
-                    textAlign = TextAlign.Center
+                    textAlign = TextAlign.Center,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
                 )
                 Spacer(modifier = Modifier.height(8.dp))
                 Text(
                     text = "Tap the + button to upload an image and create a new puzzle",
                     style = MaterialTheme.typography.bodyMedium,
-                    textAlign = TextAlign.Center
+                    textAlign = TextAlign.Center,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
                 )
             }
         } else {
@@ -219,13 +228,18 @@ fun PuzzleItem(
     puzzle: Puzzle,
     onClick: () -> Unit
 ) {
+    val ext = LocalExtendedColors.current
     Card(
         modifier = Modifier
             .fillMaxWidth()
             .aspectRatio(1f)
             .clickable(onClick = onClick),
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
-        shape = RoundedCornerShape(12.dp)
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = ext.cardBackground,
+            contentColor = ext.onCardBackground
+        )
     ) {
         Box(
             modifier = Modifier.fillMaxSize()
@@ -265,7 +279,9 @@ fun PuzzleItem(
                     Text(
                         text = puzzle.name.take(2).uppercase(),
                         style = MaterialTheme.typography.headlineLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
                     )
                 }
             }
@@ -317,18 +333,22 @@ fun PuzzleItem(
                     ) {
                         Text(
                             text = puzzle.difficulty.name,
-                            style = MaterialTheme.typography.bodySmall
+                            style = MaterialTheme.typography.bodySmall,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
                         )
                         
                         Spacer(modifier = Modifier.width(8.dp))
                         
                         Text(
                             text = "${puzzle.difficulty.gridSize}x${puzzle.difficulty.gridSize}",
-                            style = MaterialTheme.typography.bodySmall
+                            style = MaterialTheme.typography.bodySmall,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
                         )
                     }
                 }
             }
         }
     }
-} 
+}

--- a/app/src/main/java/com/md/mypuzzleapp/presentation/home/UploadImageDialog.kt
+++ b/app/src/main/java/com/md/mypuzzleapp/presentation/home/UploadImageDialog.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import coil.compose.rememberAsyncImagePainter
@@ -72,7 +73,9 @@ fun UploadImageDialog(
             Text(
                 text = "Upload Custom Puzzle",
                 style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.Bold
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
             )
         },
         text = {
@@ -119,7 +122,9 @@ fun UploadImageDialog(
                             Spacer(modifier = Modifier.height(8.dp))
                             Text(
                                 text = "Tap to select an image",
-                                style = MaterialTheme.typography.bodyMedium
+                                style = MaterialTheme.typography.bodyMedium,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
                             )
                             Spacer(modifier = Modifier.height(8.dp))
                             TextButton(
@@ -133,7 +138,7 @@ fun UploadImageDialog(
                                     contentDescription = "Get Random Image"
                                 )
                                 Spacer(modifier = Modifier.width(8.dp))
-                                Text("Get Random Image")
+                                Text("Get Random Image", maxLines = 1, overflow = TextOverflow.Ellipsis)
                             }
                         }
                     }
@@ -145,7 +150,7 @@ fun UploadImageDialog(
                 OutlinedTextField(
                     value = imageName,
                     onValueChange = onNameChanged,
-                    label = { Text("Puzzle Name") },
+                    label = { Text("Puzzle Name", maxLines = 1, overflow = TextOverflow.Ellipsis) },
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true
                 )
@@ -159,7 +164,7 @@ fun UploadImageDialog(
                     OutlinedTextField(
                         value = selectedDifficulty.name,
                         onValueChange = {},
-                        label = { Text("Difficulty") },
+                        label = { Text("Difficulty", maxLines = 1, overflow = TextOverflow.Ellipsis) },
                         modifier = Modifier
                             .fillMaxWidth()
                             .clickable { showDifficultyDropdown = true },
@@ -175,7 +180,9 @@ fun UploadImageDialog(
                             DropdownMenuItem(
                                 text = { 
                                     Text(
-                                        text = "${difficulty.name} (${difficulty.gridSize}x${difficulty.gridSize})"
+                                        text = "${difficulty.name} (${difficulty.gridSize}x${difficulty.gridSize})",
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis
                                     ) 
                                 },
                                 onClick = {
@@ -203,7 +210,7 @@ fun UploadImageDialog(
                 },
                 enabled = selectedImageUri != null && imageName.isNotBlank() && !isLoading
             ) {
-                Text("Upload")
+                Text("Upload", maxLines = 1, overflow = TextOverflow.Ellipsis)
             }
         },
         dismissButton = {
@@ -211,7 +218,7 @@ fun UploadImageDialog(
                 onClick = onDismiss,
                 enabled = !isLoading
             ) {
-                Text("Cancel")
+                Text("Cancel", maxLines = 1, overflow = TextOverflow.Ellipsis)
             }
         }
     )

--- a/app/src/main/java/com/md/mypuzzleapp/ui/theme/Color.kt
+++ b/app/src/main/java/com/md/mypuzzleapp/ui/theme/Color.kt
@@ -2,6 +2,70 @@ package com.md.mypuzzleapp.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
+// Vibrant, accessible palette (light)
+val md_theme_light_primary = Color(0xFF5B5BD6) // Indigo 500
+val md_theme_light_onPrimary = Color(0xFFFFFFFF)
+val md_theme_light_primaryContainer = Color(0xFFE0E0FF)
+val md_theme_light_onPrimaryContainer = Color(0xFF12123A)
+
+val md_theme_light_secondary = Color(0xFF00AFA3) // Teal 500
+val md_theme_light_onSecondary = Color(0xFF003732)
+val md_theme_light_secondaryContainer = Color(0xFFBBF1EC)
+val md_theme_light_onSecondaryContainer = Color(0xFF00201D)
+
+val md_theme_light_tertiary = Color(0xFFFF7A59) // Coral/Orange
+val md_theme_light_onTertiary = Color(0xFF4A1607)
+val md_theme_light_tertiaryContainer = Color(0xFFFFD8CC)
+val md_theme_light_onTertiaryContainer = Color(0xFF2B0A02)
+
+val md_theme_light_background = Color(0xFFFBF8FF)
+val md_theme_light_onBackground = Color(0xFF191C20)
+val md_theme_light_surface = Color(0xFFFEFBFF)
+val md_theme_light_onSurface = Color(0xFF1B1B1F)
+val md_theme_light_surfaceVariant = Color(0xFFE3E1EC)
+val md_theme_light_onSurfaceVariant = Color(0xFF46464F)
+val md_theme_light_outline = Color(0xFF767680)
+val md_theme_light_outlineVariant = Color(0xFFC7C5D0)
+val md_theme_light_inverseSurface = Color(0xFF303034)
+val md_theme_light_inverseOnSurface = Color(0xFFF2F0F4)
+val md_theme_light_inversePrimary = Color(0xFFBEC2FF)
+val md_theme_light_error = Color(0xFFB3261E)
+val md_theme_light_onError = Color(0xFFFFFFFF)
+val md_theme_light_errorContainer = Color(0xFFF9DEDC)
+val md_theme_light_onErrorContainer = Color(0xFF410E0B)
+
+// Vibrant, accessible palette (dark)
+val md_theme_dark_primary = Color(0xFFBEC2FF)
+val md_theme_dark_onPrimary = Color(0xFF12123A)
+val md_theme_dark_primaryContainer = Color(0xFF3E3E9A)
+val md_theme_dark_onPrimaryContainer = Color(0xFFE0E0FF)
+
+val md_theme_dark_secondary = Color(0xFF7ADAD1)
+val md_theme_dark_onSecondary = Color(0xFF003733)
+val md_theme_dark_secondaryContainer = Color(0xFF005048)
+val md_theme_dark_onSecondaryContainer = Color(0xFFBBF1EC)
+
+val md_theme_dark_tertiary = Color(0xFFFFB59B)
+val md_theme_dark_onTertiary = Color(0xFF4A1607)
+val md_theme_dark_tertiaryContainer = Color(0xFF7A2F18)
+val md_theme_dark_onTertiaryContainer = Color(0xFFFFD8CC)
+
+val md_theme_dark_background = Color(0xFF101114)
+val md_theme_dark_onBackground = Color(0xFFE2E2E6)
+val md_theme_dark_surface = Color(0xFF111318)
+val md_theme_dark_onSurface = Color(0xFFE3E2E6)
+val md_theme_dark_surfaceVariant = Color(0xFF46464F)
+val md_theme_dark_onSurfaceVariant = Color(0xFFC7C5D0)
+val md_theme_dark_outline = Color(0xFF91909A)
+val md_theme_dark_outlineVariant = Color(0xFF46464F)
+val md_theme_dark_inverseSurface = Color(0xFFE3E2E6)
+val md_theme_dark_inverseOnSurface = Color(0xFF1B1B1F)
+val md_theme_dark_inversePrimary = Color(0xFF5B5BD6)
+val md_theme_dark_error = Color(0xFFF2B8B5)
+val md_theme_dark_onError = Color(0xFF601410)
+val md_theme_dark_errorContainer = Color(0xFF8C1D18)
+val md_theme_dark_onErrorContainer = Color(0xFFF9DEDC)
+
 val Purple80 = Color(0xFFD0BCFF)
 val PurpleGrey80 = Color(0xFFCCC2DC)
 val Pink80 = Color(0xFFEFB8C8)

--- a/app/src/main/java/com/md/mypuzzleapp/ui/theme/Dimens.kt
+++ b/app/src/main/java/com/md/mypuzzleapp/ui/theme/Dimens.kt
@@ -1,0 +1,25 @@
+package com.md.mypuzzleapp.ui.theme
+
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+// Standard spacing and sizes for consistent layout rhythm
+object Dimens {
+    // Spacing
+    val spaceXS = 4.dp
+    val spaceS = 8.dp
+    val spaceM = 16.dp
+    val spaceL = 24.dp
+    val spaceXL = 32.dp
+
+    // Icon sizes
+    val iconS = 18.dp
+    val iconM = 24.dp
+    val iconL = 32.dp
+
+    // Touch targets
+    val minTouch = 48.dp
+
+    // Text sizes (if needed outside Typography)
+    val counterText = 20.sp
+}

--- a/app/src/main/java/com/md/mypuzzleapp/ui/theme/Elevations.kt
+++ b/app/src/main/java/com/md/mypuzzleapp/ui/theme/Elevations.kt
@@ -1,0 +1,13 @@
+package com.md.mypuzzleapp.ui.theme
+
+import androidx.compose.ui.unit.dp
+
+// Centralized elevation levels (Material 3 aligned)
+object Elevations {
+    val level0 = 0.dp
+    val level1 = 1.dp
+    val level2 = 3.dp
+    val level3 = 6.dp
+    val level4 = 8.dp
+    val level5 = 12.dp
+}

--- a/app/src/main/java/com/md/mypuzzleapp/ui/theme/ExtendedColors.kt
+++ b/app/src/main/java/com/md/mypuzzleapp/ui/theme/ExtendedColors.kt
@@ -1,0 +1,55 @@
+package com.md.mypuzzleapp.ui.theme
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+
+@Immutable
+data class ExtendedColors(
+    val primaryBackground: Color,
+    val onPrimaryBackground: Color,
+    val secondaryBackground: Color,
+    val onSecondaryBackground: Color,
+    val cardBackground: Color,
+    val onCardBackground: Color,
+    val tileBackground: Color,
+    val onTileBackground: Color,
+    val fabBackground: Color,
+    val onFabBackground: Color,
+    val puzzlePieceBackground: Color,
+    val onPuzzlePieceBackground: Color
+)
+
+val LocalExtendedColors = staticCompositionLocalOf {
+    // Sensible defaults, overridden by Theme provider
+    ExtendedColors(
+        primaryBackground = Color(0xFFE0E0FF),
+        onPrimaryBackground = Color(0xFF12123A),
+        secondaryBackground = Color(0xFFBBF1EC),
+        onSecondaryBackground = Color(0xFF00201D),
+        cardBackground = Color.White,
+        onCardBackground = Color(0xFF1B1B1F),
+        tileBackground = Color(0xFFE3E1EC),
+        onTileBackground = Color(0xFF46464F),
+        fabBackground = Color(0xFF5B5BD6),
+        onFabBackground = Color.White,
+        puzzlePieceBackground = Color(0xFFFFD8CC),
+        onPuzzlePieceBackground = Color(0xFF2B0A02)
+    )
+}
+
+fun extendedColorsFrom(colorScheme: ColorScheme): ExtendedColors = ExtendedColors(
+    primaryBackground = colorScheme.primaryContainer,
+    onPrimaryBackground = colorScheme.onPrimaryContainer,
+    secondaryBackground = colorScheme.secondaryContainer,
+    onSecondaryBackground = colorScheme.onSecondaryContainer,
+    cardBackground = colorScheme.surface,
+    onCardBackground = colorScheme.onSurface,
+    tileBackground = colorScheme.surfaceVariant,
+    onTileBackground = colorScheme.onSurfaceVariant,
+    fabBackground = colorScheme.primary,
+    onFabBackground = colorScheme.onPrimary,
+    puzzlePieceBackground = colorScheme.tertiaryContainer,
+    onPuzzlePieceBackground = colorScheme.onTertiaryContainer
+)

--- a/app/src/main/java/com/md/mypuzzleapp/ui/theme/Motion.kt
+++ b/app/src/main/java/com/md/mypuzzleapp/ui/theme/Motion.kt
@@ -1,0 +1,17 @@
+package com.md.mypuzzleapp.ui.theme
+
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.Easing
+import androidx.compose.animation.core.tween
+
+// Subtle motion specs to be used for interactive feedback
+object Motion {
+    val emphasize: Easing = CubicBezierEasing(0.2f, 0f, 0f, 1f)
+    val standard: Easing = CubicBezierEasing(0.2f, 0f, 0f, 1f)
+    val decelerate: Easing = CubicBezierEasing(0f, 0f, 0f, 1f)
+
+    // 120–200ms for snappy interactions
+    fun fast() = tween<Int>(durationMillis = 120, easing = standard)
+    fun medium() = tween<Int>(durationMillis = 180, easing = standard)
+    fun slow() = tween<Int>(durationMillis = 240, easing = decelerate)
+}

--- a/app/src/main/java/com/md/mypuzzleapp/ui/theme/Shapes.kt
+++ b/app/src/main/java/com/md/mypuzzleapp/ui/theme/Shapes.kt
@@ -1,0 +1,14 @@
+package com.md.mypuzzleapp.ui.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Shapes
+import androidx.compose.ui.unit.dp
+
+// Medium-to-large rounded corners for a playful puzzle feel
+val AppShapes = Shapes(
+    extraSmall = RoundedCornerShape(6.dp),
+    small = RoundedCornerShape(10.dp),
+    medium = RoundedCornerShape(16.dp),
+    large = RoundedCornerShape(20.dp),
+    extraLarge = RoundedCornerShape(28.dp)
+)

--- a/app/src/main/java/com/md/mypuzzleapp/ui/theme/Theme.kt
+++ b/app/src/main/java/com/md/mypuzzleapp/ui/theme/Theme.kt
@@ -3,12 +3,16 @@ package com.md.mypuzzleapp.ui.theme
 import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material.ripple.LocalRippleTheme
+import androidx.compose.material.ripple.RippleAlpha
+import androidx.compose.material.ripple.RippleTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
@@ -16,25 +20,63 @@ import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
 private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
-    secondary = PurpleGrey80,
-    tertiary = Pink80
+    primary = md_theme_dark_primary,
+    onPrimary = md_theme_dark_onPrimary,
+    primaryContainer = md_theme_dark_primaryContainer,
+    onPrimaryContainer = md_theme_dark_onPrimaryContainer,
+    secondary = md_theme_dark_secondary,
+    onSecondary = md_theme_dark_onSecondary,
+    secondaryContainer = md_theme_dark_secondaryContainer,
+    onSecondaryContainer = md_theme_dark_onSecondaryContainer,
+    tertiary = md_theme_dark_tertiary,
+    onTertiary = md_theme_dark_onTertiary,
+    tertiaryContainer = md_theme_dark_tertiaryContainer,
+    onTertiaryContainer = md_theme_dark_onTertiaryContainer,
+    error = md_theme_dark_error,
+    onError = md_theme_dark_onError,
+    errorContainer = md_theme_dark_errorContainer,
+    onErrorContainer = md_theme_dark_onErrorContainer,
+    background = md_theme_dark_background,
+    onBackground = md_theme_dark_onBackground,
+    surface = md_theme_dark_surface,
+    onSurface = md_theme_dark_onSurface,
+    surfaceVariant = md_theme_dark_surfaceVariant,
+    onSurfaceVariant = md_theme_dark_onSurfaceVariant,
+    outline = md_theme_dark_outline,
+    outlineVariant = md_theme_dark_outlineVariant,
+    inverseSurface = md_theme_dark_inverseSurface,
+    inverseOnSurface = md_theme_dark_inverseOnSurface,
+    inversePrimary = md_theme_dark_inversePrimary
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
-    secondary = PurpleGrey40,
-    tertiary = Pink40
-
-    /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-    */
+    primary = md_theme_light_primary,
+    onPrimary = md_theme_light_onPrimary,
+    primaryContainer = md_theme_light_primaryContainer,
+    onPrimaryContainer = md_theme_light_onPrimaryContainer,
+    secondary = md_theme_light_secondary,
+    onSecondary = md_theme_light_onSecondary,
+    secondaryContainer = md_theme_light_secondaryContainer,
+    onSecondaryContainer = md_theme_light_onSecondaryContainer,
+    tertiary = md_theme_light_tertiary,
+    onTertiary = md_theme_light_onTertiary,
+    tertiaryContainer = md_theme_light_tertiaryContainer,
+    onTertiaryContainer = md_theme_light_onTertiaryContainer,
+    error = md_theme_light_error,
+    onError = md_theme_light_onError,
+    errorContainer = md_theme_light_errorContainer,
+    onErrorContainer = md_theme_light_onErrorContainer,
+    background = md_theme_light_background,
+    onBackground = md_theme_light_onBackground,
+    surface = md_theme_light_surface,
+    onSurface = md_theme_light_onSurface,
+    surfaceVariant = md_theme_light_surfaceVariant,
+    onSurfaceVariant = md_theme_light_onSurfaceVariant,
+    outline = md_theme_light_outline,
+    outlineVariant = md_theme_light_outlineVariant,
+    inverseSurface = md_theme_light_inverseSurface,
+    inverseOnSurface = md_theme_light_inverseOnSurface,
+    inversePrimary = md_theme_light_inversePrimary
 )
 
 @Composable
@@ -62,9 +104,24 @@ fun MyPuzzleAppTheme(
         }
     }
 
-    MaterialTheme(
-        colorScheme = colorScheme,
-        typography = Typography,
-        content = content
-    )
+    // Build extended backgrounds from the resolved color scheme
+    val extended = extendedColorsFrom(colorScheme)
+
+    CompositionLocalProvider(
+        LocalRippleTheme provides object : RippleTheme {
+            @Composable override fun defaultColor() = colorScheme.primary
+            @Composable override fun rippleAlpha(): RippleAlpha = RippleTheme.defaultRippleAlpha(
+                contentColor = colorScheme.primary,
+                lightTheme = !darkTheme
+            )
+        },
+        LocalExtendedColors provides extended
+    ) {
+        MaterialTheme(
+            colorScheme = colorScheme,
+            typography = Typography,
+            shapes = AppShapes,
+            content = content
+        )
+    }
 }

--- a/app/src/main/java/com/md/mypuzzleapp/ui/theme/Type.kt
+++ b/app/src/main/java/com/md/mypuzzleapp/ui/theme/Type.kt
@@ -6,29 +6,48 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
-// Set of Material typography styles to start with
+// Material 3 Typography tuned for a playful puzzle vibe
 val Typography = Typography(
-    bodyLarge = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 16.sp,
-        lineHeight = 24.sp,
-        letterSpacing = 0.5.sp
-    )
-    /* Other default text styles to override
+    displaySmall = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Black,
+        fontSize = 34.sp,
+        lineHeight = 40.sp,
+        letterSpacing = (-0.25).sp
+    ),
     titleLarge = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Bold,
         fontSize = 22.sp,
         lineHeight = 28.sp,
         letterSpacing = 0.sp
     ),
-    labelSmall = TextStyle(
-        fontFamily = FontFamily.Default,
+    titleMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 18.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.15.sp
+    ),
+    bodyLarge = TextStyle(
+        fontFamily = FontFamily.SansSerif,
         fontWeight = FontWeight.Medium,
-        fontSize = 11.sp,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.2.sp
+    ),
+    labelLarge = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 14.sp,
+        lineHeight = 20.sp,
+        letterSpacing = 0.2.sp
+    ),
+    labelMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Medium,
+        fontSize = 12.sp,
         lineHeight = 16.sp,
-        letterSpacing = 0.5.sp
+        letterSpacing = 0.3.sp
     )
-    */
 )


### PR DESCRIPTION
- Add theme tokens: Dimens, Elevations, Motion, Shapes, ExtendedColors
- Replace seed colors with generated M3 light/dark color schemes in `Theme.kt`
- Provide `LocalExtendedColors` and custom ripple via `CompositionLocalProvider`
- Update `Typography` for playful puzzle vibe and add titles/labels
- Expand `Color.kt` palette for both light/dark schemes
- Apply new theme tokens across UI screens (Home, Puzzle, Upload dialog)
- Minor UI polish and consistency (spacing, shapes, elevations)